### PR TITLE
Add Basic to project list

### DIFF
--- a/src/projects.js
+++ b/src/projects.js
@@ -248,6 +248,15 @@ const projects = [
         'A library for writing yourself a text editor.'
       )
     },
+    { title: 'Basic'
+    , contact: 'Luka Horvat, Nikola Henezi'
+    , skillLevel: 'beginner'
+    , skillLevelTo: 'expert'
+    , homepage: 'https://gitlab.com/haskell-hr/basic'
+    , children: (
+        'Database first database library with focus on: type safety, ease of use, flexibility and user friendly error messages'
+      )
+    },
 ];
 
 


### PR DESCRIPTION
This is kinda a late addition, but I would love to include [Basic](https://gitlab.alternation.hr/open-source/basic) to the Zurihac project list. In short, it is a database first database library that we (@LukaHorvat and me) have been working for almost a year now and we would love a chance to show you what have we done so far, and what do we have planned for the future.

Thanks!