### PR TITLE
Added massiv library to 2018 projects.

### DIFF
--- a/src/projects.js
+++ b/src/projects.js
@@ -31,6 +31,15 @@ const projects = [
     , children: (
         'arithmoi is a Haskell library for number theory: modular arithmetic, primes, elliptic curves, etc. It is also an excellent tool for Project Euler.'
       )
+    },
+    { title: 'massiv'
+    , contact: 'Alexey Kuleshevich'
+    , skillLevel: 'beginner'
+    , skillLevelTo: 'expert'
+    , homepage: 'https://github.com/lehins/massiv'
+    , children: (
+        'massiv is a Haskell library for manipulating multi-dimensional Arrays. It features fusion, stencils and parallel computation.'
+      )
     }
 ];
 


### PR DESCRIPTION
I'd like to recommend this newly released package [massiv](https://hackage.haskell.org/package/massiv) to be one of the projects that Haskellers can hack on during ZuriHac 2018. More info on the package is on it's github page [github.com/lehins/massiv](https://github.com/lehins/massiv)