### PR TITLE
Typo and formatting fixes for projects.js

### DIFF
--- a/src/projects.js
+++ b/src/projects.js
@@ -27,7 +27,7 @@ const projects = [
     , contact: 'Dierk König'
     , skillLevel: 'beginner'
     , skillLevelTo: 'expert'
-    , homepage: 'http://frege-lang.org/'
+    , homepage: 'https://github.com/Frege/frege#readme'
     , children: (
         'Learn how to use Haskell in your Java projects, incl. type-safe interaction with Java libraries.'
       )
@@ -317,7 +317,7 @@ const projects = [
     , contact: 'Mauro Bieg'
     , skillLevel: 'beginner'
     , skillLevelTo: 'beginner'
-    , homepage: 'http://pandoc.org'
+    , homepage: 'https://pandoc.org'
     , children: (
         ''
       )
@@ -361,7 +361,7 @@ const projects = [
     , contact: 'Pepe Iborra'
     , skillLevel: 'beginner'
     , skillLevelTo: 'advanced'
-    , homepage: 'http://github.com/ndmitchell/debug'
+    , homepage: 'https://github.com/ndmitchell/debug'
     , children: (
         'A debugging toolkit for Haskell'
       )
@@ -427,7 +427,7 @@ const projects = [
     , contact: 'Gabriel Gonzalez'
     , skillLevel: 'advanced'
     , skillLevelTo: 'advanced'
-    , homepage: 'http://dhall-lang.org'
+    , homepage: 'https://dhall-lang.org'
     , children: (
         'Non-Turing-complete configuration language'
       )
@@ -438,7 +438,7 @@ const projects = [
     , contact: 'Jeremy Barisch-Rooney'
     , skillLevel: 'beginner'
     , skillLevelTo: 'beginner'
-    , homepage: 'https://github.com/barischrooneyj/disco/edit/master/README.org'
+    , homepage: 'https://github.com/barischrooneyj/disco#readme'
     , children: (
         "It's all in the homepage :)"
       )

--- a/src/projects.js
+++ b/src/projects.js
@@ -69,7 +69,7 @@ const projects = [
         "WIP: A clone of Ravensburger's Labyrinth."
       )
     },
-    
+
 
     { title: 'Ginger'
     , contact: 'Tobias Dammers'
@@ -80,7 +80,7 @@ const projects = [
         'Jinja2-style HTML template engine'
       )
     },
-    
+
 
     { title: 'Secure Haskell Programming with LiquidHaskell'
     , contact: 'Alexander Diemand'
@@ -91,7 +91,7 @@ const projects = [
         "Let's dig into Haskell code (libraries, apps or yours) and have a look at how we can prove termination and correct behaviour with LiquidHaskell. Beyound 'head', there are a lot of pitfalls. A vivid discussion and hands-on coding is envisaged."
       )
     },
-    
+
 
     { title: 'IHaskell'
     , contact: 'Vaibhav Sagar'
@@ -99,10 +99,10 @@ const projects = [
     , skillLevelTo: 'expert'
     , homepage: 'https://github.com/gibiansky/IHaskell'
     , children: (
-        'A Haskell kernel for Jupyter notebooks '
+        'A Haskell kernel for Jupyter notebooks'
       )
     },
-    
+
 
     { title: 'Cabal'
     , contact: 'Mikhail Glushenkov'
@@ -113,7 +113,7 @@ const projects = [
         'Common Architecture for Building Applications and Libraries'
       )
     },
-    
+
 
     { title: 'Rome'
     , contact: 'Tommaso Piazza'
@@ -124,7 +124,7 @@ const projects = [
         'Binary dependency cache specialized for macOS/tvOS/watchOS/iOS'
       )
     },
-    
+
 
     { title: 'Nomyx'
     , contact: 'Corentin'
@@ -135,7 +135,6 @@ const projects = [
         'The game in which you can change the rules!'
       )
     },
-    
 
     { title: 'Enzo Haussecker'
     , contact: 'Enzo Haussecker'
@@ -143,10 +142,10 @@ const projects = [
     , skillLevelTo: 'expert'
     , homepage: 'https://dfinity.org'
     , children: (
-        'We have developed a cryptographic protocol that allows a network of computers to reach a consensus on a stream of random values. A  probabilistic mechanism for leader ranking is applied to these random values, which drives the production of blocks for a public blockchain.'
+        'We have developed a cryptographic protocol that allows a network of computers to reach a consensus on a stream of random values. A probabilistic mechanism for leader ranking is applied to these random values, which drives the production of blocks for a public blockchain.'
       )
     },
-    
+
 
     { title: 'stackage2nix'
     , contact: 'Dmitry Bushev'
@@ -157,7 +156,7 @@ const projects = [
         'Generate Nix build instructions from a Stack file'
       )
     },
-    
+
 
     { title: 'life-sync'
     , contact: 'Dmitrii Kovanikov'
@@ -168,7 +167,7 @@ const projects = [
         'CLI tool which helps you to synchronize dotfiles repositories'
       )
     },
-    
+
 
     { title: 'Haskell Project Project'
     , contact: 'Matt Parsons'
@@ -179,7 +178,7 @@ const projects = [
         'Are you curious about doing Haskell, but not sure where to start? This is a Haskell project that is designed to connect beginners, mentors, and ideas.'
       )
     },
-    
+
 
     { title: 'Quid2'
     , contact: ' Pasqualino Titto Assini'
@@ -190,9 +189,9 @@ const projects = [
         'Open, evolvable, consistent and efficient distributed systems'
       )
     },
-    
 
-    { title: 'News Engine '
+
+    { title: 'News Engine'
     , contact: 'Vidas Pleta'
     , skillLevel: 'beginner'
     , skillLevelTo: 'beginner'
@@ -201,7 +200,7 @@ const projects = [
         'Self driving news engine that would help to personalize user content.'
       )
     },
-    
+
 
     { title: 'Basic'
     , contact: 'Nikola Henezi'
@@ -234,7 +233,7 @@ const projects = [
         'Small project for different ODE solvers for haskell, in particular symplectic solvers.'
       )
     },
-    
+
 
     { title: 'GRIN'
     , contact: 'Csaba Hruska'
@@ -242,10 +241,10 @@ const projects = [
     , skillLevelTo: 'advanced'
     , homepage: 'https://github.com/andorp/grin'
     , children: (
-        'The name GRIN is short for Graph Reduction Intermediate Notation, and it is an intermediate language for graph reduction.  It can be used as a Haskell backend replacing STG.'
+        'The name GRIN is short for Graph Reduction Intermediate Notation, and it is an intermediate language for graph reduction. It can be used as a Haskell backend replacing STG.'
       )
     },
-    
+
 
     { title: 'Purely functional data structures'
     , contact: 'Juan Carlos Saenz-Carrasco'
@@ -267,7 +266,7 @@ const projects = [
         'Haskell compiler infastructure for WebAssembly'
       )
     },
-    
+
 
     { title: 'Quasar-lite'
     , contact: 'Pawel Szulc'
@@ -278,7 +277,7 @@ const projects = [
         "It's an abstraction for a File System build with Free. Attendees will write interpreters for storages of their choice (like HDFS, Elasticsearch, PostgreSQL). At the end of hackhaton we will get a nice website that allows you to connect (mount) to specific storage, list, write and read its content"
       )
     },
-    
+
 
     { title: 'Transity'
     , contact: 'Adrian Sieber'
@@ -289,7 +288,7 @@ const projects = [
         'The plain text accounting tool of the future'
       )
     },
-    
+
 
     { title: 'Building music types'
     , contact: 'Drew Krause'
@@ -300,7 +299,7 @@ const projects = [
         'Modeling compositional forms (pitch &/or rhythm) using algebraic data types'
       )
     },
-    
+
 
     { title: 'sparse-linear-algebra'
     , contact: 'Marco Zocca'
@@ -311,7 +310,7 @@ const projects = [
         'A native linear algebra library with multiple backends'
       )
     },
-    
+
 
     { title: 'pandoc'
     , contact: 'Mauro Bieg'
@@ -322,7 +321,7 @@ const projects = [
         ''
       )
     },
-    
+
 
     { title: 'butler'
     , contact: 'Nicolas Mattia'
@@ -333,7 +332,7 @@ const projects = [
         'just-add-water session types for safe and easy protocols and state machines'
       )
     },
-    
+
 
     { title: 'Motor'
     , contact: 'Oskar Wickström'
@@ -344,7 +343,7 @@ const projects = [
         "Motor is an experimental Haskell library for building finite-state machines with type-safe transitions and effects. It draws inspiration from the Idris ST library. I'd be interested in working with others on this, exploring the design space further."
       )
     },
-    
+
 
     { title: 'vindinium-rage'
     , contact: 'Sergey Mironov'
@@ -355,7 +354,7 @@ const projects = [
         'Game agent for vindinium.org on-line AI competition'
       )
     },
-    
+
 
     { title: 'Debug'
     , contact: 'Pepe Iborra'
@@ -366,7 +365,7 @@ const projects = [
         'A debugging toolkit for Haskell'
       )
     },
-    
+
 
     { title: 'easytensor'
     , contact: 'Artem Chirkin'
@@ -377,7 +376,7 @@ const projects = [
         'Strongly-typed multidimensional numerical data and operations'
       )
     },
-    
+
 
     { title: 'Refract'
     , contact: 'Philip Kamenarsky'
@@ -388,7 +387,7 @@ const projects = [
         'Optical Purescript UI library based on React and the Elm architecture, but without the boilerplate.'
       )
     },
-    
+
 
     { title: 'Haskell CodingBat'
     , contact: 'Pawel Kruszewski'
@@ -399,7 +398,7 @@ const projects = [
         'CodingBat like website for exercising Haskell.'
       )
     },
-    
+
 
     { title: 'Flare Timing'
     , contact: 'Phil de Joux'
@@ -410,7 +409,7 @@ const projects = [
         'Scoring for Free Flight Competition'
       )
     },
-    
+
 
     { title: 'Compiler Development'
     , contact: 'Stephen Diehl'
@@ -421,7 +420,7 @@ const projects = [
         'We will informally hack on various tooling on llvm-hs toolchain and related projects.'
       )
     },
-    
+
 
     { title: 'Dhall'
     , contact: 'Gabriel Gonzalez'
@@ -432,7 +431,7 @@ const projects = [
         'Non-Turing-complete configuration language'
       )
     },
-    
+
 
     { title: 'Distributed Algorithms Framework'
     , contact: 'Jeremy Barisch-Rooney'
@@ -443,7 +442,7 @@ const projects = [
         "It's all in the homepage :)"
       )
     },
-    
+
 ];
 
 const Star = () => (<div className={styles.star}>{starIcon}</div>);

--- a/src/projects.js
+++ b/src/projects.js
@@ -23,13 +23,13 @@ const projects = [
         'opencv is a Haskell library providing a binding to the OpenCV-3.x C++ library. It binds directly with the C++ API using the inline-c Haskell library.'
       )
     },
-    { title: 'Frege - a Haskell for Java Programmers'
+    { title: 'Frege'
     , contact: 'Dierk König'
     , skillLevel: 'beginner'
     , skillLevelTo: 'expert'
     , homepage: 'https://github.com/Frege/frege#readme'
     , children: (
-        'Learn how to use Haskell in your Java projects, incl. type-safe interaction with Java libraries.'
+        'Learn how to use Frege (a Haskell to JVM compiler) in your Java projects, incl. type-safe interaction with Java libraries.'
       )
     },
     { title: 'arithmoi'
@@ -88,7 +88,7 @@ const projects = [
     , skillLevelTo: 'expert'
     , homepage: 'https://github.com/CodiePP/'
     , children: (
-        "Let's dig into Haskell code (libraries, apps or yours) and have a look at how we can prove termination and correct behaviour with LiquidHaskell. Beyound 'head', there are a lot of pitfalls. A vivid discussion and hands-on coding is envisaged."
+        "Let's dig into Haskell code (libraries, apps or yours) and have a look at how we can prove termination and correct behaviour with LiquidHaskell. Beyond 'head', there are a lot of pitfalls. A vivid discussion and hands-on coding is envisaged."
       )
     },
 
@@ -136,7 +136,8 @@ const projects = [
       )
     },
 
-    { title: 'Enzo Haussecker'
+
+    { title: 'DFINITY'
     , contact: 'Enzo Haussecker'
     , skillLevel: 'expert'
     , skillLevelTo: 'expert'
@@ -197,13 +198,13 @@ const projects = [
     , skillLevelTo: 'beginner'
     , homepage: ''
     , children: (
-        'Self driving news engine that would help to personalize user content.'
+        'Self-driving news engine that would help to personalize user content.'
       )
     },
 
 
     { title: 'Basic'
-    , contact: 'Nikola Henezi'
+    , contact: 'Luka Horvat and Nikola Henezi'
     , skillLevel: 'beginner'
     , skillLevelTo: 'expert'
     , homepage: 'https://gitlab.com/haskell-hr/basic'
@@ -211,18 +212,7 @@ const projects = [
         'Database first database library with focus on: type safety, ease of use, flexibility and user friendly error messages'
       )
     },
-    
 
-    { title: 'Basic'
-    , contact: 'Luka Horvat'
-    , skillLevel: 'advanced'
-    , skillLevelTo: 'advanced'
-    , homepage: ''
-    , children: (
-        'Database first database library with focus on: type safety, ease of use, flexibility and user friendly error messages'
-      )
-    },
-    
 
     { title: 'Differential Equation Solvers'
     , contact: 'Dominic Steinitz'
@@ -255,9 +245,9 @@ const projects = [
         "Since Okasaki's book and PhD thesis, few efforts have been done towards the design and analysis of purely data structures, specifically the field of dynamic environment"
       )
     },
-    
 
-    { title: 'Haskell-wasm'
+
+    { title: 'haskell-wasm'
     , contact: 'Anthony Sheldon'
     , skillLevel: 'beginner'
     , skillLevelTo: 'advanced'
@@ -318,7 +308,7 @@ const projects = [
     , skillLevelTo: 'beginner'
     , homepage: 'https://pandoc.org'
     , children: (
-        ''
+        'Pandoc is a free and open-source software document converter written in Haskell'
       )
     },
 


### PR DESCRIPTION
I suspect these changes should not be objectionable:

- Made as many of the links as possible HTTPS (and I checked them all for validity)
- Fixed some whitespace mistakes that should not affect the generated page
- Combined duplicate **Basic** listings
- Shortened the name of **Frege - a Haskell for Java Programmers** to **Frege** so it fits on one line
  and modified the description to include the fact that Frege is a Haskell to JVM compiler.
- Added a short description for **pandoc** based on the first sentence of its Wikipedia page
- Fixed a typo (`s/beyound/beyond/`) in **Secure Haskell Programming with LiquidHaskell**
- Fixed a misentry in the DFINITY project listing (I also checked their website to make sure that "DFINITY" is the correct capitalization)
- Fixed capitalization of `haskell-wasm` to be consistent with organization name on GitHub