### PR TITLE
"Haskell Documentation Improvements" meta project

### DIFF
--- a/src/projects.js
+++ b/src/projects.js
@@ -333,13 +333,13 @@ const projects = [
     },
 
 
-    { title: 'Motor'
+    { title: 'Haskell Documentation Improvements'
     , contact: 'Oskar Wickström'
-    , skillLevel: 'advanced'
+    , skillLevel: 'beginner'
     , skillLevelTo: 'expert'
-    , homepage: 'https://github.com/owickstrom/motor'
+    , homepage: ''
     , children: (
-        "Motor is an experimental Haskell library for building finite-state machines with type-safe transitions and effects. It draws inspiration from the Idris ST library. I'd be interested in working with others on this, exploring the design space further."
+        "Get together and improve documentation for central Haskell packages where we think it could be better — not only API references, but tutorials, how-tos/cookbooks, and full executable examples. Let's create some pull requests!"
       )
     },
 


### PR DESCRIPTION
I'd like to swap my previous suggestion for a "meta project", focusing on improving documentation for often-used packages in the Haskell ecosystem. Many packages have decent or good Hackage API docs, but might lack in terms of tutorials and how-tos.